### PR TITLE
Fixed null returns from calling the BoosterReply class

### DIFF
--- a/Java/src/main/java/net/hypixel/api/reply/BoostersReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/BoostersReply.java
@@ -4,16 +4,16 @@ import com.google.gson.JsonArray;
 
 @SuppressWarnings("unused")
 public class BoostersReply extends AbstractReply {
-    private JsonArray records;
+    private JsonArray boosters;
 
-    public JsonArray getRecords() {
-        return records;
+    public JsonArray getBoosters() {
+        return boosters;
     }
 
     @Override
     public String toString() {
         return "BoostersReply{" +
-                "records=" + records +
+                "boosters=" + boosters +
                 ",super=" + super.toString() + "}";
     }
 }


### PR DESCRIPTION
The JSON String returned by the api when you query for the boosters is named "boosters" instead of "records". Hence the original code will return null previously as it is not able to find the JsonArray going by the name "records".