### PR TITLE
Generic type in Callback must extend AbstractCallback.

### DIFF
--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -5,10 +5,12 @@ import com.google.gson.Gson;
 import com.mastfrog.netty.http.client.HttpClient;
 import com.mastfrog.netty.http.client.ResponseFuture;
 import com.mastfrog.netty.http.client.ResponseHandler;
+
 import net.hypixel.api.reply.*;
 import net.hypixel.api.util.APIUtil;
 import net.hypixel.api.util.Callback;
 import net.hypixel.api.util.HypixelAPIException;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.UUID;
@@ -551,7 +553,7 @@ public class HypixelAPI {
         return httpClient.get().setURL(url).execute(buildResponseHandler(callback));
     }
 
-    private class SyncCallback<T> extends Callback<T> {
+    private class SyncCallback<T extends AbstractReply> extends Callback<T> {
         private Throwable failCause;
         private T result;
 

--- a/Java/src/main/java/net/hypixel/api/util/Callback.java
+++ b/Java/src/main/java/net/hypixel/api/util/Callback.java
@@ -1,6 +1,8 @@
 package net.hypixel.api.util;
 
-public abstract class Callback<T> {
+import net.hypixel.api.reply.AbstractReply;
+
+public abstract class Callback<T extends AbstractReply> {
     private final Class<T> clazz;
 
     public Callback(Class<T> clazz) {


### PR DESCRIPTION
The generic type T in the SyncCallback class within HypixelAPI.java should always extend AbstractReply.