### PR TITLE
Deploy to public maven repository

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -8,6 +8,17 @@
     <artifactId>PublicAPI</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <distributionManagement>
+        <repository>
+            <id>komp-releases</id>
+            <url>http://pomhub.uk/nexus/content/repositories/releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>komp-snapshots</id>
+            <url>http://pomhub.uk/nexus/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <repositories>
         <repository>
             <id>timboudreau-builds</id>
@@ -28,7 +39,7 @@
         <dependency>
             <groupId>com.mastfrog</groupId>
             <artifactId>netty-http-client</artifactId>
-            <version>1.4.19</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ This is a Java implementation of the Hypixel API
 ### Documentation
 Hypixel PublicAPI documentation is mostly contained within the source code and the [example code](https://github.com/HypixelDev/PublicAPI/tree/master/Example/src/main/java/net/hypixel/example).
 
+### Maven Repository
+```xml
+<repository>
+  <id>komp-repo</id>
+  <url>http://pomhub.uk/nexus/content/groups/public</url>
+</repository>
+```
+
 ### Query Limitations
 The API server has a request limit of 60 queries per minute. Abuse of the API will lead to your API key being banned.
 
@@ -25,4 +33,3 @@ HypixelAPI © 2014
 
 ### TODO
 * Add a proper copyright header to all files.
-* Deploy to a public maven repo.


### PR DESCRIPTION
This pull request:
  - Adds necessary deployment information to the pom.xml of the `Java` module
  - Modifies the version number of a missing dependency so the project builds 

The artifact has already been deployed so a merge is not _required_ but useful for later versions.