### PR TITLE
Replace Joda-Time dependency with built-in Java 8 Date-Time APIs

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -24,11 +24,6 @@
             <artifactId>httpclient</artifactId>
             <version>4.4</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.8.1</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -17,9 +17,9 @@ import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.joda.time.DateTime;
 
 import java.lang.reflect.Type;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -41,7 +41,7 @@ public class HypixelAPI {
         gson = new GsonBuilder()
                 .registerTypeAdapter(UUID.class, new UUIDTypeAdapter())
                 .registerTypeAdapter(GameType.class, new GameTypeTypeAdapter())
-                .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
+                .registerTypeAdapter(ZonedDateTime.class, new DateTimeTypeAdapter())
 
                 // guilds
                 .registerTypeAdapter(GuildReply.Guild.GuildCoinHistory.class, new GuildCoinHistoryAdapter())

--- a/Java/src/main/java/net/hypixel/api/adapters/DateTimeTypeAdapter.java
+++ b/Java/src/main/java/net/hypixel/api/adapters/DateTimeTypeAdapter.java
@@ -2,9 +2,9 @@ package net.hypixel.api.adapters;
 
 import com.google.gson.*;
 import net.hypixel.api.util.APIUtil;
-import org.joda.time.DateTime;
 
 import java.lang.reflect.Type;
+import java.time.ZonedDateTime;
 
 /**
  * Our dates are always saved as a timestamp
@@ -12,15 +12,15 @@ import java.lang.reflect.Type;
  * it in here as well by just using some more
  * parsing.
  */
-public class DateTimeTypeAdapter implements JsonDeserializer<DateTime>, JsonSerializer<DateTime> {
+public class DateTimeTypeAdapter implements JsonDeserializer<ZonedDateTime>, JsonSerializer<ZonedDateTime> {
 
     @Override
-    public JsonElement serialize(DateTime src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive(src.getMillis());
+    public JsonElement serialize(ZonedDateTime src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toInstant().toEpochMilli());
     }
 
     @Override
-    public DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public ZonedDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         return APIUtil.getDateTime(Long.parseLong(json.getAsString()));
     }
 

--- a/Java/src/main/java/net/hypixel/api/adapters/GuildCoinHistoryHoldingTypeAdapterFactory.java
+++ b/Java/src/main/java/net/hypixel/api/adapters/GuildCoinHistoryHoldingTypeAdapterFactory.java
@@ -41,7 +41,7 @@ public class GuildCoinHistoryHoldingTypeAdapterFactory<T extends GuildReply.Guil
 
         JsonObject coinHistory = new JsonObject();
         // insert as millisecond string so we can use our standard milli -> datetime conversion
-        history.getCoinHistory().entrySet().forEach(entry -> coinHistory.addProperty(String.valueOf(entry.getKey().getMillis()), entry.getValue()));
+        history.getCoinHistory().entrySet().forEach(entry -> coinHistory.addProperty(String.valueOf(entry.getKey().toInstant().toEpochMilli()), entry.getValue()));
 
         // load into the json
         obj.add("guildCoinHistory", coinHistory);

--- a/Java/src/main/java/net/hypixel/api/reply/BoostersReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/BoostersReply.java
@@ -2,8 +2,8 @@ package net.hypixel.api.reply;
 
 import net.hypixel.api.request.RequestType;
 import net.hypixel.api.util.GameType;
-import org.joda.time.DateTime;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,7 +33,7 @@ public class BoostersReply extends AbstractReply {
         private int originalLength;
         private int length;
         private GameType gameType;
-        private DateTime dateActivated;
+        private ZonedDateTime dateActivated;
 
         public UUID getPurchaserUuid() {
             return purchaserUuid;
@@ -55,7 +55,7 @@ public class BoostersReply extends AbstractReply {
             return gameType;
         }
 
-        public DateTime getDateActivated() {
+        public ZonedDateTime getDateActivated() {
             return dateActivated;
         }
 

--- a/Java/src/main/java/net/hypixel/api/reply/FriendsReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/FriendsReply.java
@@ -1,8 +1,8 @@
 package net.hypixel.api.reply;
 
 import net.hypixel.api.request.RequestType;
-import org.joda.time.DateTime;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,7 +29,7 @@ public class FriendsReply extends AbstractReply {
     public class FriendShip {
 
         private UUID uuidSender, uuidReceiver;
-        private DateTime started;
+        private ZonedDateTime started;
 
         public UUID getUuidSender() {
             return uuidSender;
@@ -39,7 +39,7 @@ public class FriendsReply extends AbstractReply {
             return uuidReceiver;
         }
 
-        public DateTime getStarted() {
+        public ZonedDateTime getStarted() {
             return started;
         }
 

--- a/Java/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -3,8 +3,8 @@ package net.hypixel.api.reply;
 import com.google.common.collect.Maps;
 import net.hypixel.api.request.RequestType;
 import net.hypixel.api.util.Banner;
-import org.joda.time.DateTime;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -47,7 +47,7 @@ public class GuildReply extends AbstractReply {
         private GuildCoinHistory guildCoinHistory;
         private int coins;
         private int coinsEver;
-        private DateTime created;
+        private ZonedDateTime created;
         private Boolean joinable;
         private int memberSizeLevel;
         private int bankSizeLevel;
@@ -91,7 +91,7 @@ public class GuildReply extends AbstractReply {
             return coinsEver;
         }
 
-        public DateTime getCreated() {
+        public ZonedDateTime getCreated() {
             return created;
         }
 
@@ -147,9 +147,9 @@ public class GuildReply extends AbstractReply {
 
         public static class GuildCoinHistory {
 
-            private Map<DateTime, Integer> coinHistory = Maps.newHashMap();
+            private Map<ZonedDateTime, Integer> coinHistory = Maps.newHashMap();
 
-            public Map<DateTime, Integer> getCoinHistory() {
+            public Map<ZonedDateTime, Integer> getCoinHistory() {
                 return coinHistory;
             }
 
@@ -164,7 +164,7 @@ public class GuildReply extends AbstractReply {
         public class Member implements GuildCoinHistoryHolding {
             private UUID uuid;
             private GuildRank rank;
-            private DateTime joined;
+            private ZonedDateTime joined;
             private GuildCoinHistory guildCoinHistory;
 
             public UUID getUuid() {
@@ -175,7 +175,7 @@ public class GuildReply extends AbstractReply {
                 return rank;
             }
 
-            public DateTime getJoined() {
+            public ZonedDateTime getJoined() {
                 return joined;
             }
 

--- a/Java/src/main/java/net/hypixel/api/util/APIUtil.java
+++ b/Java/src/main/java/net/hypixel/api/util/APIUtil.java
@@ -1,8 +1,8 @@
 package net.hypixel.api.util;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -21,7 +21,7 @@ public class APIUtil {
         return UUID.fromString(uuidPattern.matcher(stripped).replaceAll("$1-$2-$3-$4-$5"));
     }
 
-    public static DateTime getDateTime(long timeStamp) {
-        return new DateTime(timeStamp, DateTimeZone.forID("America/New_York"));
+    public static ZonedDateTime getDateTime(long timeStamp) {
+        return Instant.ofEpochMilli(timeStamp).atZone(ZoneId.of("America/New_York"));
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The Hypixel PublicAPI has the following dependencies:
 * Google Gson library
 * Guava: Google Core Libraries for Java
 * Apache HttpClient
-* Joda Time
 
 ### Bug Reporting
 You can create an issue here on GitHub to report a bug with the API or to suggest enhancements.


### PR DESCRIPTION
This replaces the Joda-Time dependency with Date-Time APIs provided by Java 8. Especially convenient for Forge modders, since all other Hypixel API for Java dependencies are already used in Minecraft/Forge code, so no additional libraries need to be downloaded.