### PR TITLE
Add Maven/Gradle instructions using JitPack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ This is a Java implementation of the Hypixel API
 Hypixel PublicAPI documentation can be found in the [Documentation](https://github.com/HypixelDev/PublicAPI/tree/master/Documentation).
 Java documentation can be found mostly in the code or [JavaDocs](https://api.hypixel.net/javadocs/).
 
+### Usage
+You can use this API as a dependency via JitPack. In the future it will be deployed to a public maven repo.
+#### Maven
+```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+```
+```xml
+<dependency>
+    <groupId>com.github.HypixelDev.PublicAPI</groupId>
+    <artifactId>Java</artifactId>
+    <version>master</version>
+</dependency>
+```
+#### Gradle
+```gradle
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+```
+```gradle
+dependencies {
+    compile 'com.github.HypixelDev.PublicAPI:Java:master'
+}
+```
 ### Query Limitations
 The API server has a request limit of 120 queries per minute. Abuse of the API will lead to your API key being banned.
 


### PR DESCRIPTION
This will help new developers to easily add the repo to their buildscripts. The wording might not be 100% perfect, but I think this is a good addition until the API is deployed to a public maven repo.