### PR TITLE
Remove Guava dependency

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -10,11 +10,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.3</version>

--- a/Java/src/main/java/net/hypixel/api/pets/PetStats.java
+++ b/Java/src/main/java/net/hypixel/api/pets/PetStats.java
@@ -1,12 +1,11 @@
 package net.hypixel.api.pets;
 
-import com.google.common.collect.Maps;
-
+import java.util.HashMap;
 import java.util.Map;
 
 public class PetStats {
 
-    private Map<PetType, Pet> petMap = Maps.newHashMap();
+    private Map<PetType, Pet> petMap = new HashMap<>();
 
     public PetStats(Map<String, Map<String, Object>> petStats) {
         for (Map.Entry<String, Map<String, Object>> stringMapEntry : petStats.entrySet()) {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ You can obtain an API key by joining ```mc.hypixel.net``` with a valid Minecraft
 ### Dependencies
 The Hypixel PublicAPI has the following dependencies:
 * Google Gson library
-* Guava: Google Core Libraries for Java
 * Apache HttpClient
 
 ### Bug Reporting


### PR DESCRIPTION
This removes Guava dependency, the only use is for `Maps.newHashMap()` that can be simply replace with `new HashMap<>()` on Java 7 and later.