### PR TITLE
Move documentation of SkyBlock item & inventory data

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -13,3 +13,4 @@ All uuid parameters are expected to have the UUID without dashes.
 ## SkyBlock items and inventories
 Items and inventory data are stored as a base64 encoded string containing gzipped nbt data.
 If a method is missing important information about an item or inventory, you should try checking this!
+>Note: the base64 string may contain a unicode escape for non-alphabetical symbols (i.e. `=` will be displayed as `\u003d`), and some programming languages may have silent defects when interpreting the string.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -9,3 +9,7 @@ Responses are served in JSON format.
 
 ## UUID Parameters
 All uuid parameters are expected to have the UUID without dashes.
+
+## SkyBlock items and inventories
+Items and inventory data are stored as a base64 encoded string containing gzipped nbt data.
+If a method is missing important information about an item or inventory, you should try checking this!

--- a/Documentation/methods/skyblock/profile.md
+++ b/Documentation/methods/skyblock/profile.md
@@ -2,7 +2,6 @@
 
 ## Description
 Returns a SkyBlock profile's data, such as stats, objectives etc. The data returned can differ depending on the players in-game API settings.
-Inventory data is stored as a base64 encoded string containing gzipped nbt data.
 
 ## Parameters
 - key


### PR DESCRIPTION
Both `skyblock/auctions` and `skyblock/profile` contain this data type, and it is better to not duplicate this information for both methods.