### PR TITLE
Make guild tag color accessible

### DIFF
--- a/Java/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -26,6 +26,7 @@ public class GuildReply extends AbstractReply {
         private String name;
         private String description;
         private String tag;
+        private String tagColor;
         private Boolean publiclyListed;
         private Banner banner;
         private List<Member> members;
@@ -50,6 +51,10 @@ public class GuildReply extends AbstractReply {
 
         public String getTag() {
             return tag;
+        }
+
+        public String getTagColor() {
+            return tagColor;
         }
 
         public Boolean getPubliclyListed() {
@@ -95,6 +100,7 @@ public class GuildReply extends AbstractReply {
                     ", name='" + name + '\'' +
                     ", description='" + description + '\'' +
                     ", tag='" + tag + '\'' +
+                    ", tagColor='" + tagColor + '\'' +
                     ", publiclyListed=" + publiclyListed +
                     ", banner=" + banner +
                     ", members=" + members +


### PR DESCRIPTION
Closes #243 
A String is used to store the tag color instead of an enum because we already have too many color enums that exist. Also Enum#valueOf(String) exists.