### PR TITLE
Fix null key owner in Java API

### DIFF
--- a/Java/src/main/java/net/hypixel/api/reply/KeyReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/KeyReply.java
@@ -1,5 +1,6 @@
 package net.hypixel.api.reply;
 
+import com.google.gson.annotations.SerializedName;
 import java.util.UUID;
 
 public class KeyReply extends AbstractReply {
@@ -18,6 +19,7 @@ public class KeyReply extends AbstractReply {
 
     public class Key {
         private UUID key;
+        @SerializedName("owner")
         private UUID ownerUuid;
         private int totalQueries;
         private int queriesInPastMin;


### PR DESCRIPTION
Closes #266 

Since sometime around #240, the `ownerUuid` field in the `/key` endpoint was renamed to `owner`. This PR reflects that change in the Java API, which is currently returning null for the owner's UUID.