### PR TITLE
Remove key parameter for skyblock/auctions

### DIFF
--- a/Documentation/methods/skyblock/auctions.md
+++ b/Documentation/methods/skyblock/auctions.md
@@ -4,7 +4,6 @@
 Returns SkyBlock auctions that are currently active in the in-game Auction House. This method uses pagination due to the amount of results returned. Each page will return up to 1,000 results.
 
 ## Parameters
-- key
 - page (Zero indexed and defaults to 0)
 
 ## Example Response


### PR DESCRIPTION
You don't need an API key to get all auctions anymore