### PR TITLE
Add an implicit rate limiter to help with bulk-operation security (Tested)

### DIFF
--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class HypixelAPI {
+    private static final int DEFAULT_MAX_REQUESTS_PER_MINUTE = 120;
 
     private static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(UUID.class, new UUIDTypeAdapter())
@@ -48,7 +49,7 @@ public class HypixelAPI {
 
         this.executorService = Executors.newCachedThreadPool();
         this.httpClient = HttpClientBuilder.create().build();
-        this.rateLimiter = new RateLimiter();
+        this.rateLimiter = new RateLimiter(DEFAULT_MAX_REQUESTS_PER_MINUTE);
     }
 
     /**

--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -52,19 +52,18 @@ public class HypixelAPI {
     }
 
     /**
-     * Set how many requests this API instance is allowed to make in one minute. If more requests attempt
-     * to pass past this limit in one minute, they will need to wait for the next minute.
+     * Set how many requests this API instance is allowed to make in one minute.
+     * <p>If more requests attempt to pass past this limit in one minute,
+     * they will need to wait for the next minute. Default is 120.
      *
-     * <p>Default: 120
-     *
-     * @param limitPerMinute The new limit
+     * @param limitPerMinute The new limit.
      */
     public void setRateLimit(int limitPerMinute) {
         rateLimiter.setRate(limitPerMinute);
     }
 
     /**
-     * Shuts down the internal executor service
+     * Shuts down the internal executor service and rate limiter service.
      */
     public void shutdown() {
         executorService.shutdown();
@@ -262,7 +261,7 @@ public class HypixelAPI {
 
             executorService.submit(() -> {
                 try {
-                    rateLimiter.block();
+                    rateLimiter.beforeAction();
 
                     R response = httpClient.execute(new HttpGet(url.toString()), obj -> {
                         String content = EntityUtils.toString(obj.getEntity(), "UTF-8");

--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -41,7 +41,7 @@ public class HypixelAPI {
 
     private final ExecutorService executorService;
     private final HttpClient httpClient;
-    private RateLimiter rateLimiter;
+    private final RateLimiter rateLimiter;
 
     public HypixelAPI(UUID apiKey) {
         this.apiKey = apiKey;

--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -59,8 +59,7 @@ public class HypixelAPI {
      *
      * @param limitPerMinute The new limit
      */
-    public void setRateLimit(int limitPerMinute)
-    {
+    public void setRateLimit(int limitPerMinute) {
         rateLimiter.setRate(limitPerMinute);
     }
 

--- a/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
+++ b/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
@@ -7,11 +7,17 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class RateLimiter {
 	private final Object lock = new Object();
+
 	private final ScheduledExecutorService resetter = Executors.newSingleThreadScheduledExecutor();
-	private volatile int limitPerMinute = 120;
+	private volatile int limitPerMinute;
 	private int actionsThisMinute;
 
-	public RateLimiter() {
+	/**
+	 * @param limitPerMinute Maximum amount of times {@link RateLimiter#beforeAction()} can be called in the same minute
+	 *                       before it begins blocking threads until the next minute.
+	 */
+	public RateLimiter(int limitPerMinute) {
+		this.limitPerMinute = limitPerMinute;
 		resetter.scheduleAtFixedRate(this::reset, 1, 1, MINUTES);
 	}
 
@@ -23,7 +29,7 @@ public class RateLimiter {
 	}
 
 	/**
-	 * Set the action queue limit to be used by {@link RateLimiter#beforeAction()}. Default is 120.
+	 * Set the action queue limit to be used by {@link RateLimiter#beforeAction()}.
 	 *
 	 * @param limitPerMinute The new limit.
 	 */

--- a/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
+++ b/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
@@ -5,32 +5,26 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-public class RateLimiter
-{
+public class RateLimiter {
 	private int limitPerMinute = 120;
 	private int requestsThisMinute;
 	private final Object lock = new Object();
 	private final ScheduledExecutorService refresher = Executors.newSingleThreadScheduledExecutor();
 
-	public RateLimiter()
-	{
+	public RateLimiter() {
 		refresher.scheduleAtFixedRate(() -> {
 			requestsThisMinute = 0;
 			lock.notifyAll();
 		}, 1, 1, MINUTES);
 	}
 
-	public void setRate(int limitPerMinute)
-	{
+	public void setRate(int limitPerMinute) {
 		this.limitPerMinute = limitPerMinute;
 	}
 
-	public void block() throws InterruptedException
-	{
-		synchronized ( lock )
-		{
-			while (requestsThisMinute >= limitPerMinute)
-			{
+	public void block() throws InterruptedException {
+		synchronized ( lock ) {
+			while (requestsThisMinute >= limitPerMinute) {
 				lock.wait();
 			}
 
@@ -38,8 +32,7 @@ public class RateLimiter
 		}
 	}
 
-	public void shutdown()
-	{
+	public void shutdown() {
 		refresher.shutdown();
 	}
 }

--- a/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
+++ b/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
@@ -9,7 +9,7 @@ public class RateLimiter {
 	private final Object lock = new Object();
 	private final ScheduledExecutorService resetter = Executors.newSingleThreadScheduledExecutor();
 	private volatile int limitPerMinute = 120;
-	private int requestsThisMinute;
+	private int actionsThisMinute;
 
 	public RateLimiter() {
 		resetter.scheduleAtFixedRate(this::reset, 1, 1, MINUTES);
@@ -17,25 +17,39 @@ public class RateLimiter {
 
 	private void reset() {
 		synchronized ( lock ) {
-			requestsThisMinute = 0;
+			actionsThisMinute = 0;
 			lock.notifyAll();
 		}
 	}
 
+	/**
+	 * Set the action queue limit to be used by {@link RateLimiter#beforeAction()}. Default is 120.
+	 *
+	 * @param limitPerMinute The new limit.
+	 */
 	public void setRate(int limitPerMinute) {
 		this.limitPerMinute = limitPerMinute;
 	}
 
-	public void block() throws InterruptedException {
+	/**
+	 * Blocks the current thread in the event that the action queue has been filled for this minute.
+	 * Unblocks when the queue refreshes.
+	 *
+	 * @throws InterruptedException If interrupted while waiting.
+	 */
+	public void beforeAction() throws InterruptedException {
 		synchronized ( lock ) {
-			while (requestsThisMinute >= limitPerMinute) {
+			while (actionsThisMinute >= limitPerMinute) {
 				lock.wait();
 			}
 
-			requestsThisMinute++;
+			actionsThisMinute++;
 		}
 	}
 
+	/**
+	 * Shut down the internal executor service.
+	 */
 	public void shutdown() {
 		resetter.shutdown();
 	}

--- a/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
+++ b/Java/src/main/java/net/hypixel/api/util/RateLimiter.java
@@ -1,0 +1,45 @@
+package net.hypixel.api.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class RateLimiter
+{
+	private int limitPerMinute = 120;
+	private int requestsThisMinute;
+	private final Object lock = new Object();
+	private final ScheduledExecutorService refresher = Executors.newSingleThreadScheduledExecutor();
+
+	public RateLimiter()
+	{
+		refresher.scheduleAtFixedRate(() -> {
+			requestsThisMinute = 0;
+			lock.notifyAll();
+		}, 1, 1, MINUTES);
+	}
+
+	public void setRate(int limitPerMinute)
+	{
+		this.limitPerMinute = limitPerMinute;
+	}
+
+	public void block() throws InterruptedException
+	{
+		synchronized ( lock )
+		{
+			while (requestsThisMinute >= limitPerMinute)
+			{
+				lock.wait();
+			}
+
+			requestsThisMinute++;
+		}
+	}
+
+	public void shutdown()
+	{
+		refresher.shutdown();
+	}
+}


### PR DESCRIPTION
Issue #316 

Felt like doing it myself

**Edit: Class fully tested**
I ran this test case multiple times. It is 100% consistent with my expectations.
```java
public class RateLimiterTest
{
    private static final int TEST_LIMIT = 120;
    private static final int TEST_DEVIATION = 30;
    private final ExecutorService testAsyncPool = newCachedThreadPool();

    private final RateLimiter testInstance = new RateLimiter(TEST_LIMIT);
    private final AtomicInteger actionPassCounter = new AtomicInteger();

    /**
     * If the action is attempted N times at once, where N < LIMIT, all should pass
     */
    @Test
    public void testAllPassBelowLimit() throws InterruptedException
    {
        int underLimit = TEST_LIMIT - TEST_DEVIATION;

        for (int i = 0; i < underLimit; i++)
        {
            testAsyncPool.submit(this::limitedIncrementCounter);
        }

        Thread.sleep(2000);
        assertEquals(underLimit, actionPassCounter.intValue());
    }

    /**
     * If the action is attempted N times, where N > LIMIT, LIMIT times should pass, and LIMIT - N threads should freeze
     */
    @Test
    public void testNotAllPassOverLimit() throws InterruptedException
    {
        int overLimit = TEST_LIMIT + TEST_DEVIATION;

        for (int i = 0; i < overLimit; i++)
        {
            testAsyncPool.submit(this::limitedIncrementCounter);
        }

        Thread.sleep(2000);
        assertEquals(TEST_LIMIT, actionPassCounter.intValue());
    }

    private void limitedIncrementCounter()
    {
        try
        {
            testInstance.beforeAction();
            actionPassCounter.incrementAndGet();
        }
        catch (InterruptedException e)
        {
            Thread.currentThread().interrupt();
        }
    }
}
```
![image](https://user-images.githubusercontent.com/31541490/101388148-682be100-3874-11eb-8980-9a64ad395aed.png)
