### PR TITLE
Update Example pom.xml to have the correct references

### DIFF
--- a/Example/pom.xml
+++ b/Example/pom.xml
@@ -25,12 +25,18 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>Hypixel</id>
+            <url>https://repo.hypixel.net/repository/Hypixel/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>net.hypixel</groupId>
-            <artifactId>Java</artifactId>
-            <version>2.0.0</version>
+            <artifactId>HypixelAPI</artifactId>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
The Example maven module had a pom.xml with an incorrect dependency and also did not have the new hypixel repository linked to it, thus the module was unable to be used by people when trying to run the examples.

Resolves #341 