### PR TITLE
Capture ratelimit-remaining and ratelimit-reset headers in AbstractReply

### DIFF
--- a/Java/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/Java/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -13,7 +13,6 @@ import net.hypixel.api.reply.*;
 import net.hypixel.api.reply.skyblock.*;
 import net.hypixel.api.util.GameType;
 import net.hypixel.api.util.ResourceType;
-import org.apache.http.Header;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -24,8 +23,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 public class HypixelAPI {
 

--- a/Java/src/main/java/net/hypixel/api/reply/AbstractReply.java
+++ b/Java/src/main/java/net/hypixel/api/reply/AbstractReply.java
@@ -6,6 +6,9 @@ public abstract class AbstractReply {
     protected boolean success;
     protected String cause;
 
+    transient protected int limitLeft;
+    transient protected int limitReset;
+
     public boolean isThrottle() {
         return throttle;
     }
@@ -18,12 +21,35 @@ public abstract class AbstractReply {
         return cause;
     }
 
+    public int getRequestAmountLeft()
+    {
+        return limitLeft;
+    }
+
+    public void setRequestAmountLeft(int limitLeft)
+    {
+        this.limitLeft = limitLeft;
+    }
+
+    public int getSecondsTillReset()
+    {
+        return limitReset;
+    }
+
+    public void setSecondsTillReset(int limitReset)
+    {
+        this.limitReset = limitReset;
+    }
+
+
     @Override
     public String toString() {
         return "AbstractReply{" +
                 "throttle=" + throttle +
                 ", success=" + success +
                 ", cause='" + cause + '\'' +
+                ", limitLeft=" + limitLeft +
+                ", limitReset=" + limitReset +
                 '}';
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <version>2.0-SNAPSHOT</version>
 
     <modules>
+        <!--Removed due to incorrect reference https://github.com/HypixelDev/PublicAPI/pull/342 fixed this already-->
         <!--<module>Example</module>-->
         <module>Java</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>2.0-SNAPSHOT</version>
 
     <modules>
-        <module>Example</module>
+        <!--<module>Example</module>-->
         <module>Java</module>
     </modules>
 


### PR DESCRIPTION
This is a handy addition to provide an easy way to know how many requests this key has left and how many seconds until the request counter for this key gets reset all shipped with the reply.