### PR TITLE
Remove key parameter from bazaar endpoint

### DIFF
--- a/Documentation/methods/skyblock/bazaar.md
+++ b/Documentation/methods/skyblock/bazaar.md
@@ -4,7 +4,7 @@
 Returns the list of [products](#product-description) along with their sell summary, buy summary and quick status.
 
 ## Parameters
-- key
+None
 
 ## Example Response
 ```js


### PR DESCRIPTION
You don't need the `?key` parameter for the bazaar endpoint, try it out in your browser console:

```js
fetch("https://api.hypixel.net/skyblock/bazaar").then(res => res.json()).then(console.log)
```