### PR TITLE
Critical Bugfix - Sometimes, the reactor transport stops working

### DIFF
--- a/hypixel-api-transport-reactor/src/main/java/net/hypixel/api/reactor/ReactorHttpClient.java
+++ b/hypixel-api-transport-reactor/src/main/java/net/hypixel/api/reactor/ReactorHttpClient.java
@@ -139,7 +139,7 @@ public class ReactorHttpClient implements HypixelHttpClient {
             while (this.actionsLeftThisMinute <= 0) {
                 this.limitResetCondition.await();
             }
-            this.actionsLeftThisMinute = Math.max(0, this.actionsLeftThisMinute--);
+            this.actionsLeftThisMinute--;
         } finally {
             this.lock.unlock();
         }
@@ -192,7 +192,6 @@ public class ReactorHttpClient implements HypixelHttpClient {
         if (this.firstRequestReturned.compareAndSet(false, true)) {
             int timeRemaining = Math.max(1, response.responseHeaders().getInt("ratelimit-reset", 10));
             int requestsRemaining = response.responseHeaders().getInt("ratelimit-remaining", 110);
-
 
             this.setActionsLeftThisMinute(requestsRemaining);
 

--- a/hypixel-api-transport-reactor/src/main/java/net/hypixel/api/reactor/ReactorHttpClient.java
+++ b/hypixel-api-transport-reactor/src/main/java/net/hypixel/api/reactor/ReactorHttpClient.java
@@ -18,8 +18,11 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class ReactorHttpClient implements HypixelHttpClient {
+
     private final HttpClient httpClient;
     private final UUID apiKey;
 
@@ -34,7 +37,8 @@ public class ReactorHttpClient implements HypixelHttpClient {
     // For shutting down the flux that emits request callbacks
     private final Disposable requestCallbackFluxDisposable;
 
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition limitResetCondition = lock.newCondition();
 
     /*
      * How many requests we can send before reaching the limit
@@ -62,13 +66,8 @@ public class ReactorHttpClient implements HypixelHttpClient {
                     callback = blockingQueue.take();
                 }
 
-                synchronized (lock) {
-                    while (this.actionsLeftThisMinute <= 0) {
-                        lock.wait();
-                    }
+                this.decrementActionsOrWait();
 
-                    actionsLeftThisMinute--;
-                }
                 synchronousSink.next(callback);
             } catch (InterruptedException e) {
                 throw new AssertionError("This should not have been possible", e);
@@ -89,7 +88,7 @@ public class ReactorHttpClient implements HypixelHttpClient {
     }
 
     /**
-     * Canceling the returned future will result in canceling the request if possible
+     * Canceling the returned future will result in canceling the sending of the request if still possible
      */
     @Override
     public CompletableFuture<HypixelHttpResponse> makeRequest(String url) {
@@ -97,7 +96,7 @@ public class ReactorHttpClient implements HypixelHttpClient {
     }
 
     /**
-     * Canceling the returned future will result in canceling the request if possible
+     * Canceling the returned future will result in canceling the sending of the request if still possible
      */
     @Override
     public CompletableFuture<HypixelHttpResponse> makeAuthenticatedRequest(String url) {
@@ -115,7 +114,7 @@ public class ReactorHttpClient implements HypixelHttpClient {
     }
 
     /**
-     * Makes a request to the Hypixel api and returns a {@link Mono<Tuple2<String, Integer>>} containing
+     * Makes a request to the Hypixel api and returns a {@link Mono} containing
      * the response body and status code, canceling this mono will prevent the request from being sent if possible
      *
      * @param path            full url
@@ -134,6 +133,39 @@ public class ReactorHttpClient implements HypixelHttpClient {
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
+    private void decrementActionsOrWait() throws InterruptedException {
+        this.lock.lock();
+        try {
+            while (this.actionsLeftThisMinute <= 0) {
+                this.limitResetCondition.await();
+            }
+            this.actionsLeftThisMinute = Math.max(0, this.actionsLeftThisMinute--);
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
+
+    private void incrementActionsLeftThisMinute() {
+        this.lock.lock();
+        try {
+            this.actionsLeftThisMinute++;
+            this.limitResetCondition.signal();
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
+    private void setActionsLeftThisMinute(int value) {
+        this.lock.lock();
+        try {
+            this.actionsLeftThisMinute = Math.max(0, value);
+            this.limitResetCondition.signal();
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
     /**
      * Reads response status and retries error 429 (too many requests)
      * The first request after every limit reset will be used to schedule the next limit reset
@@ -144,12 +176,11 @@ public class ReactorHttpClient implements HypixelHttpClient {
      */
     private ResponseHandlingResult handleResponse(HttpClientResponse response, RequestCallback requestCallback) throws InterruptedException {
         if (response.status() == HttpResponseStatus.TOO_MANY_REQUESTS) {
+            System.out.println("Too many requests were sent, is something else using the same API Key?!!");
             int timeRemaining = Math.max(1, response.responseHeaders().getInt("ratelimit-reset", 10));
 
             if (this.overflowStartedNewClock.compareAndSet(false, true)) {
-                synchronized (lock) {
-                    this.actionsLeftThisMinute = 0;
-                }
+                this.setActionsLeftThisMinute(0);
                 resetForFirstRequest(timeRemaining);
             }
 
@@ -162,10 +193,8 @@ public class ReactorHttpClient implements HypixelHttpClient {
             int timeRemaining = Math.max(1, response.responseHeaders().getInt("ratelimit-reset", 10));
             int requestsRemaining = response.responseHeaders().getInt("ratelimit-remaining", 110);
 
-            synchronized (lock) {
-                this.actionsLeftThisMinute = requestsRemaining;
-                lock.notifyAll();
-            }
+
+            this.setActionsLeftThisMinute(requestsRemaining);
 
             resetForFirstRequest(timeRemaining);
         }
@@ -182,10 +211,7 @@ public class ReactorHttpClient implements HypixelHttpClient {
         Schedulers.parallel().schedule(() -> {
             this.firstRequestReturned.set(false);
             this.overflowStartedNewClock.set(false);
-            synchronized (lock) {
-                this.actionsLeftThisMinute = 1;
-                lock.notifyAll();
-            }
+            this.setActionsLeftThisMinute(1);
         }, timeRemaining + 2, TimeUnit.SECONDS);
     }
 
@@ -194,37 +220,43 @@ public class ReactorHttpClient implements HypixelHttpClient {
      */
     private static class RequestCallback {
         private final String url;
-        private final MonoSink<Tuple2<String, Integer>> monoSink;
+        private final MonoSink<Tuple2<String, Integer>> requestResultSink;
         private final ReactorHttpClient requestRateLimiter;
         private final boolean isAuthenticated;
+        private final ReentrantLock lock = new ReentrantLock();
         private boolean isCanceled = false;
 
-        private RequestCallback(String url, MonoSink<Tuple2<String, Integer>> monoSink, boolean isAuthenticated, ReactorHttpClient requestRateLimiter) {
+        private RequestCallback(String url, MonoSink<Tuple2<String, Integer>> requestResultSink, boolean isAuthenticated, ReactorHttpClient requestRateLimiter) {
             this.url = url;
-            this.monoSink = monoSink;
+            this.requestResultSink = requestResultSink;
             this.requestRateLimiter = requestRateLimiter;
             this.isAuthenticated = isAuthenticated;
 
-            this.monoSink.onCancel(() -> {
-                synchronized (this) {
-                    this.isCanceled = true;
-                }
-            });
+            this.requestResultSink.onCancel(this::setCanceled);
+        }
+
+        private void setCanceled() {
+            this.lock.lock();
+            try {
+                this.isCanceled = true;
+            } finally {
+                this.lock.unlock();
+            }
         }
 
         public boolean isCanceled() {
-            return this.isCanceled;
+            this.lock.lock();
+            try {
+                return this.isCanceled;
+            } finally {
+                this.lock.unlock();
+            }
         }
 
         private void sendRequest() {
-            synchronized (this) {
-                if (isCanceled) {
-                    synchronized (this.requestRateLimiter.lock) {
-                        this.requestRateLimiter.actionsLeftThisMinute++;
-                        this.requestRateLimiter.lock.notifyAll();
-                    }
-                    return;
-                }
+            if (this.isCanceled()) {
+                this.requestRateLimiter.incrementActionsLeftThisMinute();
+                return;
             }
 
             (this.isAuthenticated ? requestRateLimiter.httpClient.headers(headers -> headers.add("API-Key", requestRateLimiter.apiKey.toString())) : requestRateLimiter.httpClient).get()
@@ -238,10 +270,10 @@ public class ReactorHttpClient implements HypixelHttpClient {
                             }
                             return Mono.empty();
                         } catch (InterruptedException e) {
-                            monoSink.error(e);
+                            this.requestResultSink.error(e);
                             throw new AssertionError("ERROR: Queue insertion got interrupted, serious problem! (this should not happen!!)", e);
                         }
-                    }).subscribe(this.monoSink::success);
+                    }).subscribe(this.requestResultSink::success);
         }
     }
 


### PR DESCRIPTION
I found out the reactor transport was bugged due to a mistake in concurrency. Since I'm the author of this particular part of the code I assume I should fix it as well. I have refactored the code using the `java.util.concurrent.locks` package into safer code while fixing said bug. Fixes #461 