### PR TITLE
Refactor ResourceReply into appropriate package

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/ResourceReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/ResourceReply.java
@@ -1,4 +1,4 @@
-package net.hypixel.api.reply.skyblock;
+package net.hypixel.api.reply;
 
 import com.google.gson.JsonObject;
 import net.hypixel.api.reply.AbstractReply;


### PR DESCRIPTION
Closes #515 
Moved ResourceReply to `net.hypixel.api.reply` as it has no relationship to SkyBlock.