### PR TITLE
Added Wool Wars to GameType Enum

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/data/type/GameType.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/data/type/GameType.java
@@ -30,7 +30,7 @@ public enum GameType implements ServerType {
     PIT("Pit", "Pit", 64),
     REPLAY("Replay", "Replay", 65),
     SMP("SMP", "SMP", 67),
-    WOOL_GAMES("Wool Wars", "WoolGames", 68)
+    WOOL_GAMES("Wool Wars", "WoolGames", 68),
     ;
 
     private static final GameType[] VALUES = values();

--- a/hypixel-api-core/src/main/java/net/hypixel/api/data/type/GameType.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/data/type/GameType.java
@@ -30,6 +30,7 @@ public enum GameType implements ServerType {
     PIT("Pit", "Pit", 64),
     REPLAY("Replay", "Replay", 65),
     SMP("SMP", "SMP", 67),
+    WOOL_GAMES("Wool Wars", "WoolGames", 68)
     ;
 
     private static final GameType[] VALUES = values();


### PR DESCRIPTION
Due to release of Wool Wars, the API throws an error when requesting due to unable to find Wool Wars. Updated the Enum to fix the parsing.