### PR TITLE
Changing the guildExp data type from integer to long

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -54,7 +54,7 @@ public class GuildReply extends AbstractReply {
         private List<Member> members;
         private List<Rank> ranks;
         private List<GameType> preferredGames;
-        private Map<GameType, Double> guildExpByGameType;
+        private Map<GameType, Long> guildExpByGameType;
         private Map<GuildAchievement, Integer> achievements;
         private int coins;
         private int coinsEver;
@@ -202,14 +202,14 @@ public class GuildReply extends AbstractReply {
          * @return the amount of XP earned by the guild for the specified {@code game}.
          * @throws IllegalArgumentException if the provided {@code game} is {@code null}.
          */
-        public double getExperienceForGame(GameType game) {
+        public long getExperienceForGame(GameType game) {
             if (game == null) {
                 throw new IllegalArgumentException("Cannot get XP for null GameType");
             }
 
             return Optional.ofNullable(guildExpByGameType)
                 .map(expByGame -> expByGame.get(game))
-                .orElse(0.0);
+                .orElse(0L);
         }
 
         /**

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -54,7 +54,7 @@ public class GuildReply extends AbstractReply {
         private List<Member> members;
         private List<Rank> ranks;
         private List<GameType> preferredGames;
-        private Map<GameType, Integer> guildExpByGameType;
+        private Map<GameType, Double> guildExpByGameType;
         private Map<GuildAchievement, Integer> achievements;
         private int coins;
         private int coinsEver;
@@ -202,14 +202,14 @@ public class GuildReply extends AbstractReply {
          * @return the amount of XP earned by the guild for the specified {@code game}.
          * @throws IllegalArgumentException if the provided {@code game} is {@code null}.
          */
-        public int getExperienceForGame(GameType game) {
+        public double getExperienceForGame(GameType game) {
             if (game == null) {
                 throw new IllegalArgumentException("Cannot get XP for null GameType");
             }
 
             return Optional.ofNullable(guildExpByGameType)
                 .map(expByGame -> expByGame.get(game))
-                .orElse(0);
+                .orElse(0.0);
         }
 
         /**

--- a/hypixel-api-example/src/main/java/net/hypixel/api/example/GetGuildExample.java
+++ b/hypixel-api-example/src/main/java/net/hypixel/api/example/GetGuildExample.java
@@ -180,7 +180,7 @@ public class GetGuildExample {
          * Then we loop through each game and see how much experience the guild's earned from it.
          */
         for (GameType game : GameType.values()) {
-            int experienceForGame = guild.getExperienceForGame(game);
+            double experienceForGame = guild.getExperienceForGame(game);
             System.out.println("\t" + game.getName() + ": " + experienceForGame);
         }
     }

--- a/hypixel-api-example/src/main/java/net/hypixel/api/example/GetGuildExample.java
+++ b/hypixel-api-example/src/main/java/net/hypixel/api/example/GetGuildExample.java
@@ -180,7 +180,7 @@ public class GetGuildExample {
          * Then we loop through each game and see how much experience the guild's earned from it.
          */
         for (GameType game : GameType.values()) {
-            double experienceForGame = guild.getExperienceForGame(game);
+            long experienceForGame = guild.getExperienceForGame(game);
             System.out.println("\t" + game.getName() + ": " + experienceForGame);
         }
     }


### PR DESCRIPTION
Changing the guildExp data type from integer to long, as there are guilds that have more exp than the integer limit provides for.

Fixes #536