### PR TITLE
Implement a RateLimit object to contain the rate limit headers in replies

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -154,6 +154,10 @@ public class HypixelAPI {
         );
     }
 
+    /**
+     * @deprecated Endpoint is deprecated and will be removed on 14th August 2023.
+     */
+    @Deprecated
     public CompletableFuture<KeyReply> getKey() {
         return get(KeyReply.class, "key");
     }
@@ -304,7 +308,13 @@ public class HypixelAPI {
                     if (clazz == ResourceReply.class) {
                         return checkReply((R) new ResourceReply(Utilities.GSON.fromJson(response.getBody(), JsonObject.class)));
                     }
-                    return checkReply(Utilities.GSON.fromJson(response.getBody(), clazz));
+
+                    R reply = Utilities.GSON.fromJson(response.getBody(), clazz);
+                    if (reply instanceof RateLimitedReply) {
+                        ((RateLimitedReply) reply).setRateLimit(response.getRateLimit());
+                    }
+
+                    return checkReply(reply);
                 });
     }
 

--- a/hypixel-api-core/src/main/java/net/hypixel/api/http/HypixelHttpResponse.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/http/HypixelHttpResponse.java
@@ -4,10 +4,17 @@ public class HypixelHttpResponse {
 
     private final int statusCode;
     private final String body;
+    private final RateLimit rateLimit;
 
+    @Deprecated
     public HypixelHttpResponse(int statusCode, String body) {
+        this(statusCode, body, null);
+    }
+
+    public HypixelHttpResponse(int statusCode, String body, RateLimit rateLimit) {
         this.statusCode = statusCode;
         this.body = body;
+        this.rateLimit = rateLimit;
     }
 
     public int getStatusCode() {
@@ -16,5 +23,9 @@ public class HypixelHttpResponse {
 
     public String getBody() {
         return body;
+    }
+
+    public RateLimit getRateLimit() {
+        return rateLimit;
     }
 }

--- a/hypixel-api-core/src/main/java/net/hypixel/api/http/RateLimit.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/http/RateLimit.java
@@ -16,18 +16,31 @@ public class RateLimit {
         this.resetAt = new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(reset));
     }
 
+    /**
+     * @return the total limit allowed for the used API key per interval
+     */
     public int getLimit() {
         return limit;
     }
 
+    /**
+     * @return the remaining amount of requests for the used API key during this interval
+     */
     public int getRemaining() {
         return remaining;
     }
 
+    /**
+     * @return the time in seconds until the limit interval resets
+     */
     public int getReset() {
         return reset;
     }
 
+    /**
+     * @return the date at which time the limit interval resets, this date won't be accurate to the millisecond due to
+     * the only context being in seconds
+     */
     public Date getResetAt() {
         return resetAt;
     }

--- a/hypixel-api-core/src/main/java/net/hypixel/api/http/RateLimit.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/http/RateLimit.java
@@ -1,0 +1,44 @@
+package net.hypixel.api.http;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class RateLimit {
+    private final int limit;
+    private final int remaining;
+    private final int reset;
+    private final Date resetAt;
+
+    public RateLimit(int limit, int remaining, int reset) {
+        this.limit = limit;
+        this.remaining = remaining;
+        this.reset = reset;
+        this.resetAt = new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(reset));
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public int getRemaining() {
+        return remaining;
+    }
+
+    public int getReset() {
+        return reset;
+    }
+
+    public Date getResetAt() {
+        return resetAt;
+    }
+
+    @Override
+    public String toString() {
+        return "RateLimit{" +
+                "limit=" + limit +
+                ", remaining=" + remaining +
+                ", reset=" + reset +
+                ", resetAt=" + resetAt +
+                '}';
+    }
+}

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/BoostersReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/BoostersReply.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public class BoostersReply extends AbstractReply {
+public class BoostersReply extends RateLimitedReply {
     private List<Booster> boosters;
     private BoosterState boosterState;
 

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/CountsReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/CountsReply.java
@@ -2,7 +2,7 @@ package net.hypixel.api.reply;
 
 import java.util.Map;
 
-public class CountsReply extends AbstractReply {
+public class CountsReply extends RateLimitedReply {
     private Map<String, GameCount> games;
     private int playerCount;
 

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/FindGuildReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/FindGuildReply.java
@@ -1,6 +1,6 @@
 package net.hypixel.api.reply;
 
-public class FindGuildReply extends AbstractReply {
+public class FindGuildReply extends RateLimitedReply {
     private String guild;
 
     /**

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -1,22 +1,18 @@
 package net.hypixel.api.reply;
 
 import com.google.gson.annotations.SerializedName;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 import net.hypixel.api.data.type.GameType;
 import net.hypixel.api.data.type.GuildAchievement;
 import net.hypixel.api.reply.PlayerReply.Player;
 import net.hypixel.api.util.Banner;
 
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.*;
+
 // Suppressed because most fields are assigned by Gson via reflection.
 @SuppressWarnings({"unused", "RedundantSuppression", "MismatchedQueryAndUpdateOfCollection"})
-public class GuildReply extends AbstractReply {
+public class GuildReply extends RateLimitedReply {
 
     private Guild guild;
 

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/KeyReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/KeyReply.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.UUID;
 
-public class KeyReply extends AbstractReply {
+public class KeyReply extends RateLimitedReply {
     private Key record;
 
     public Key getRecord() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/LeaderboardsReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/LeaderboardsReply.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public class LeaderboardsReply extends AbstractReply {
+public class LeaderboardsReply extends RateLimitedReply {
     private Map<GameType, List<Leaderboard>> leaderboards;
 
     public Map<GameType, List<Leaderboard>> getLeaderboards() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/PlayerReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/PlayerReply.java
@@ -16,7 +16,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.UUID;
 
-public class PlayerReply extends AbstractReply {
+public class PlayerReply extends RateLimitedReply {
 
     // Suppressed because this field is dynamically assigned by Gson using reflection.
     @SuppressWarnings({"unused", "RedundantSuppression"})

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/PunishmentStatsReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/PunishmentStatsReply.java
@@ -2,7 +2,7 @@ package net.hypixel.api.reply;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PunishmentStatsReply extends AbstractReply {
+public class PunishmentStatsReply extends RateLimitedReply {
     @SerializedName("staff_rollingDaily")
     private int staffRollingDaily;
     @SerializedName("staff_total")

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/RateLimitedReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/RateLimitedReply.java
@@ -1,0 +1,22 @@
+package net.hypixel.api.reply;
+
+import net.hypixel.api.http.RateLimit;
+
+public abstract class RateLimitedReply extends AbstractReply {
+    private RateLimit rateLimit;
+
+    public RateLimit getRateLimit() {
+        return rateLimit;
+    }
+
+    public void setRateLimit(RateLimit rateLimit) {
+        this.rateLimit = rateLimit;
+    }
+
+    @Override
+    public String toString() {
+        return "RateLimitedReply{" +
+                "rateLimit=" + rateLimit +
+                "} " + super.toString();
+    }
+}

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/RecentGamesReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/RecentGamesReply.java
@@ -5,7 +5,7 @@ import net.hypixel.api.data.type.GameType;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-public class RecentGamesReply extends AbstractReply {
+public class RecentGamesReply extends RateLimitedReply {
 
     private List<GameSession> games;
 

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/StatusReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/StatusReply.java
@@ -3,7 +3,7 @@ package net.hypixel.api.reply;
 import com.google.gson.annotations.SerializedName;
 import net.hypixel.api.data.type.ServerType;
 
-public class StatusReply extends AbstractReply {
+public class StatusReply extends RateLimitedReply {
 
     /**
      * {@link StatusReply.Session} instance of player

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockNewsReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockNewsReply.java
@@ -2,9 +2,9 @@ package net.hypixel.api.reply.skyblock;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import net.hypixel.api.reply.AbstractReply;
+import net.hypixel.api.reply.RateLimitedReply;
 
-public class SkyBlockNewsReply extends AbstractReply {
+public class SkyBlockNewsReply extends RateLimitedReply {
     private JsonElement items;
 
     public JsonArray getItems() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockProfileReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockProfileReply.java
@@ -2,9 +2,9 @@ package net.hypixel.api.reply.skyblock;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.hypixel.api.reply.AbstractReply;
+import net.hypixel.api.reply.RateLimitedReply;
 
-public class SkyBlockProfileReply extends AbstractReply {
+public class SkyBlockProfileReply extends RateLimitedReply {
     private JsonElement profile;
 
     public JsonObject getProfile() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockProfilesReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/SkyBlockProfilesReply.java
@@ -2,9 +2,9 @@ package net.hypixel.api.reply.skyblock;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import net.hypixel.api.reply.AbstractReply;
+import net.hypixel.api.reply.RateLimitedReply;
 
-public class SkyBlockProfilesReply extends AbstractReply {
+public class SkyBlockProfilesReply extends RateLimitedReply {
     private JsonElement profiles;
 
     public JsonArray getProfiles() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/bingo/SkyBlockBingoDataReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/skyblock/bingo/SkyBlockBingoDataReply.java
@@ -1,10 +1,10 @@
 package net.hypixel.api.reply.skyblock.bingo;
 
-import net.hypixel.api.reply.AbstractReply;
+import net.hypixel.api.reply.RateLimitedReply;
 
 import java.util.List;
 
-public class SkyBlockBingoDataReply extends AbstractReply {
+public class SkyBlockBingoDataReply extends RateLimitedReply {
     private List<BingoEventData> events;
 
     public List<BingoEventData> getEvents() {

--- a/hypixel-api-example/src/main/java/net/hypixel/api/example/GetPlayerExample.java
+++ b/hypixel-api-example/src/main/java/net/hypixel/api/example/GetPlayerExample.java
@@ -121,5 +121,11 @@ public class GetPlayerExample {
          * `.getRaw()` method.
          */
         System.out.println("Raw JSON ------> " + player.getRaw());
+
+        /*
+         * RateLimit object is available to any reply from a request to an authenticated endpoint and returns context
+         * to the rate limit of the used API key.
+         */
+        System.out.println("Rate Limit ----> " + apiReply.getRateLimit());
     }
 }

--- a/hypixel-api-transport-unirest/src/main/java/net/hypixel/api/unirest/UnirestHttpClient.java
+++ b/hypixel-api-transport-unirest/src/main/java/net/hypixel/api/unirest/UnirestHttpClient.java
@@ -1,8 +1,10 @@
 package net.hypixel.api.unirest;
 
+import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
 import net.hypixel.api.http.HypixelHttpClient;
 import net.hypixel.api.http.HypixelHttpResponse;
+import net.hypixel.api.http.RateLimit;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -17,12 +19,30 @@ public class UnirestHttpClient implements HypixelHttpClient {
 
     @Override
     public CompletableFuture<HypixelHttpResponse> makeRequest(String url) {
-        return Unirest.get(url).header("User-Agent", DEFAULT_USER_AGENT).asStringAsync().thenApply(res -> new HypixelHttpResponse(res.getStatus(), res.getBody()));
+        return Unirest.get(url)
+                .header("User-Agent", DEFAULT_USER_AGENT)
+                .asStringAsync()
+                .thenApply(res -> new HypixelHttpResponse(res.getStatus(), res.getBody(), null));
     }
 
     @Override
     public CompletableFuture<HypixelHttpResponse> makeAuthenticatedRequest(String url) {
-        return Unirest.get(url).header("User-Agent", DEFAULT_USER_AGENT).header("API-Key", this.apiKey.toString()).asStringAsync().thenApply(res -> new HypixelHttpResponse(res.getStatus(), res.getBody()));
+        return Unirest.get(url)
+                .header("User-Agent", DEFAULT_USER_AGENT)
+                .header("API-Key", this.apiKey.toString())
+                .asStringAsync()
+                .thenApply(res -> new HypixelHttpResponse(res.getStatus(), res.getBody(), createRateLimitResponse(res)));
+    }
+
+    private RateLimit createRateLimitResponse(HttpResponse<String> response) {
+        if (response.getStatus() != 200) {
+            return null;
+        }
+
+        int limit = Integer.parseInt(response.getHeaders().getFirst("RateLimit-Limit"));
+        int remaining = Integer.parseInt(response.getHeaders().getFirst("RateLimit-Remaining"));
+        int reset = Integer.parseInt(response.getHeaders().getFirst("RateLimit-Reset"));
+        return new RateLimit(limit, remaining, reset);
     }
 
     @Override


### PR DESCRIPTION
As suggested in #598 this PR implements a RateLimit object that is accessible on replies to authenticated endpoints which contains information about the rate limit of the key that is in use.

Closes #598 