### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/GuildReply.java
@@ -129,7 +129,7 @@ public class GuildReply extends RateLimitedReply {
          *
          * @return the name of a Minecraft color code (all uppercase), or {@code null} if the guild
          * has never changed its tag's color.
-         * @see <a href=https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes>Color codes
+         * @see <a href=https://minecraft.wiki/w/Formatting_codes#Color_codes>Color codes
          * table</a> (uses lowercase names)
          */
         public String getTagColor() {

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/PlayerReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/PlayerReply.java
@@ -151,7 +151,7 @@ public class PlayerReply extends RateLimitedReply {
         }
 
         /**
-         * Note, returned colors use the names seen in <a href=https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes>this
+         * Note, returned colors use the names seen in <a href=https://minecraft.wiki/w/Formatting_codes#Color_codes>this
          * table</a>, in all uppercase. For example, {@code DARK_BLUE} and {@code GRAY}.
          *
          * @return The color of the player's name tag if they have MVP++. Defaults to {@code GOLD}.

--- a/hypixel-api-core/src/main/java/net/hypixel/api/util/Banner.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/util/Banner.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  *     <li>{@link Pattern#getColor()}</li>
  * </ul>
  *
- * @see <a href="https://minecraft.fandom.com/wiki/Banner">Banner</a> (Minecraft Wiki)
+ * @see <a href="https://minecraft.wiki/w/Banner">Banner</a> (Minecraft Wiki)
  */
 public class Banner {
 
@@ -116,7 +116,7 @@ public class Banner {
          * each type's identifier.
          *
          * @return the pattern's type identifier.
-         * @see <a href="https://minecraft.fandom.com/wiki/Banner/Patterns">Pattern identifiers</a>
+         * @see <a href="https://minecraft.wiki/w/Banner/Patterns">Pattern identifiers</a>
          */
         public String getType() {
             return type;


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.