### PR TITLE
Implement coverage for Housing endpoints

### DIFF
--- a/hypixel-api-core/src/main/java/net/hypixel/api/HypixelAPI.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/HypixelAPI.java
@@ -287,6 +287,14 @@ public class HypixelAPI {
         return get(false, SkyBlockFireSalesReply.class, "skyblock/firesales");
     }
 
+    // TODO: Add support for array responses so that the other endpoints can become implementable
+    public CompletableFuture<HouseReply> getHouseById(String id) {
+        return get(true, HouseReply.class, "housing/house",
+                HTTPQueryParams.create()
+                        .add("house", id)
+        );
+    }
+
     /**
      * Applies a {@code filter} to a player object when it is received in an API response.
      */

--- a/hypixel-api-core/src/main/java/net/hypixel/api/reply/HouseReply.java
+++ b/hypixel-api-core/src/main/java/net/hypixel/api/reply/HouseReply.java
@@ -1,0 +1,82 @@
+package net.hypixel.api.reply;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.time.ZonedDateTime;
+
+public class HouseReply extends RateLimitedReply {
+    private House house;
+
+    public House getHouse() { return house; }
+
+    @Override
+    public String toString() {
+        return "HouseReply{" +
+                "house=" + house +
+                "}" + super.toString();
+    }
+
+    public static class House {
+        @SerializedName("uuid") // Note: This value isn't valid UUID v4 because it has no dashes.
+        private String id;
+        @SerializedName("owner")
+        private String ownerId;
+        @SerializedName("players")
+        private Short onlinePlayers;
+
+        // Note: Houses made before full release will show as being made 1st Jan. 1970
+        private ZonedDateTime createdAt;
+        private HouseCookies cookies;
+
+        /**
+         * The house's unique identifier, a 32-character hexadecimal string not to be confused with a UUID.
+         * If the house was made during Housing's beta period, it will match the owner's Minecraft ID.
+         *
+         * @return the house's unique identifier
+         */
+        public String getId() { return id; }
+
+        /**
+         * The house owner's Minecraft ID.
+         *
+         * @return the house owner's Minecraft ID
+         */
+        public String getOwnerId() { return ownerId; }
+
+        /**
+         * The time of the house's creation, falling back to the 1st of January 1970 if
+         * the house was made during Housing's beta period (Aug. 2015 - Mar. 2020).
+         *
+         * @return the house's time of creation
+         */
+        public ZonedDateTime getCreatedAt() { return createdAt; }
+
+        /**
+         * The house's current online player count.
+         *
+         * @return the house's live player count
+         */
+        public Short getOnlinePlayers() { return onlinePlayers; }
+
+        /**
+         * The house's metrics relating to the cookies it received from players.
+         * This currently only contains the amount for the current week.
+         *
+         * @return the house's cookie metrics
+         */
+        public HouseCookies getCookies() { return cookies; }
+
+
+        public static class HouseCookies {
+            private Integer current;
+
+            /**
+             * The house's amount of received cookies for the current week, each
+             * starting on Sunday, 00:00 Toronto Local Time.
+             *
+             * @return the amount of cookies this house has received this week
+             */
+            public Integer getCurrent() { return current; }
+        }
+    }
+}


### PR DESCRIPTION
Currently has implementation for the `/housing/house` endpoint. Creating this before the other two are properly implemented due to some issues with the way they are served. (arrays at the top level instead of the usual object structure)

Will also try to make examples for these later.

Anyone willing to try their hands at these two other endpoints are welcome to do so, and I'll hopefully try to do a little work on it myself if I can find the time.